### PR TITLE
Make anonymization more useful

### DIFF
--- a/pg_format
+++ b/pg_format
@@ -1569,9 +1569,22 @@ This SQL formatter/beautifier supports keywords from SQL-92, SQL-99, SQL-2003, S
 }
 
 # Simply genreate a random string, thanks to Perlmonks
-sub generate_fake_string
+sub generate_anonymized_string
 {
-	return join('', @_[ map{ rand @_ } 1 .. shift ]);
+	my ($original, $cache) = @_;
+
+	# Prevent dates from being anonymized
+	return $original if $original =~ m{\A\d\d\d\d[/:-]\d\d[/:-]\d\d\z};
+	return $original if $original =~ m{\A\d\d[/:-]\d\d[/:-]\d\d\d\d\z};
+
+	# Range of characters to use in anonymized strings
+	my @chars = ('A'..'Z', 0..9, 'a'..'z', '-', '_', '.');
+
+	unless ($cache->{$original}) {
+		# Actual anonymized version generation
+		$cache->{$original} = join('', map { $chars[rand @chars] } 1..10 );
+	}
+	return $cache->{$original};
 }
 
 # Anonymize litteral in SQL queries by replacing parameters with fake values
@@ -1581,6 +1594,10 @@ sub anonymize_query
 
 	return if (!$orig_query);
 
+    # Variable to hold anonymized versions, so we can provide the same value
+    # for the same input, within single query.
+    my $anonymization_cache = {};
+
 	# Remove comments
 	$orig_query =~ s/\/\*(.*?)\*\///gs;
 
@@ -1588,14 +1605,8 @@ sub anonymize_query
 	$orig_query =~ s/\\'//g;
 	$orig_query =~ s/('')+//g;
 
-	# Prevent date to be anonymized
-	$orig_query =~ s/'([\d\/\-\:\s]+)'/DATEBOUNDARY$1DATEBOUNDARY/g;
-
 	# Anonymize each values
-	$orig_query =~ s/'[^']*'/"'".&generate_fake_string(10, 'A'..'Z', 0..9, 'a'..'z', '-', '_', '.')."'"/eg;
-
-	# Restore quote around date values
-	$orig_query =~ s/DATEBOUNDARY/'/g;
+	$orig_query =~ s/'([^']*)'/"'".generate_anonymized_string($1, $anonymization_cache)."'"/eg;
 
 	return $orig_query;
 }

--- a/samples/ex4.sql
+++ b/samples/ex4.sql
@@ -1,0 +1,1 @@
+SELECT 1, 2, 10, 'depesz', 'hubert', 'depesz', 'hubert depesz', '1 2 3 4';


### PR DESCRIPTION
Previously, for every string it generated anonymized version, it generated
new random string. This lead to cases like:

select *
    from tablea as a, tableb as b
    where a.whatever = 'xxx' and b.sth = 'xxx'

to have different values instead of the same 'xxx'. New version of code
keeps track of generated anonymized versions, and doesn't generate new one
when not necessary.

I also took the liberty of refactoring a bit marking things for skipping
anonymization - I think that the current way is faster (less
substitutions and relying on special strings), and it should also be
easier to extend to add new classes of things to avoid anonymization of.