### PR TITLE
Fix Beautify.pm with perl 5.20

### DIFF
--- a/lib/pgFormatter/Beautify.pm
+++ b/lib/pgFormatter/Beautify.pm
@@ -337,7 +337,7 @@ sub beautify {
                 $self->_new_line;
             }
             $self->_add_token( $token );
-            if ( $last =~ /^(?:INNER|OUTER)$/i ) {
+            if ( $last && $last =~ /^(?:INNER|OUTER)$/i ) {
                 $self->_over;
             }
         }


### PR DESCRIPTION
With perl 5.20 Beautify was giving me an error in a JOIN because $last was empty, so I've added a check on $last to see if it's empty just before matching it against a regular expression.