### PR TITLE
Unescaped ( in regex variable $last

### DIFF
--- a/lib/pgFormatter/Beautify.pm
+++ b/lib/pgFormatter/Beautify.pm
@@ -353,7 +353,7 @@ sub beautify {
         elsif ( $token eq '(' ) {
             $self->_add_token( $token );
             if ( $self->_next_token ne ')' ) {
-		$self->{ '_has_from' } = 1 if (grep(/^$last$/i, @have_from_clause));
+                $self->{ '_has_from' } = 1 if ( $last ne '(' and grep ( /^$last$/i, @have_from_clause ) );
                 $self->_new_line;
                 push @{ $self->{ '_level_stack' } }, $self->{ '_level' };
                 $self->_over unless $last and uc( $last ) eq 'WHERE';


### PR DESCRIPTION
I ran into a little trouble with a big query, 700+ lines, where the $last variable was an open parenthesis and I would get:
```
Uncaught exception: Unmatched ( in regex; marked by <-- HERE in m/^( <-- HERE $/ at /usr/local/lib/perl/5.14.2/pgFormatter/Beautify.pm line 356.
 at /usr/local/bin/pg_format line 23
	main::__ANON__('Unmatched ( in regex; marked by <-- HERE in m/^( <-- HERE $/ ...') called at /usr/local/lib/perl/5.14.2/pgFormatter/Beautify.pm line 356
	pgFormatter::Beautify::beautify('pgFormatter::Beautify=HASH(0x257f440)') called at /usr/local/lib/perl/5.14.2/pgFormatter/CLI.pm line 93
	pgFormatter::CLI::beautify('pgFormatter::CLI=HASH(0x25b97d0)') called at /usr/local/lib/perl/5.14.2/pgFormatter/CLI.pm line 69
	pgFormatter::CLI::run('pgFormatter::CLI=HASH(0x25b97d0)') called at /usr/local/bin/pg_format line 53
```
This is just a quickie change to let pg_format finish. If there are better perl escape functions, great!