### PR TITLE
Fix whatis entry of POD manpage

### DIFF
--- a/doc/pg_format.pod
+++ b/doc/pg_format.pod
@@ -1,6 +1,6 @@
-=head1 ABSTRACT
+=head1 NAME
 
-pgFormatter - PostgreSQL SQL syntax beautifier
+pg_format - PostgreSQL SQL syntax beautifier
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
Every manpage should start with a NAME section that describes the
purpose of the program. Rename ABSTRACT to NAME, and use the actual
command name.