### PR TITLE
Testsuite

### DIFF
--- a/regress_test.pl
+++ b/regress_test.pl
@@ -1,5 +1,6 @@
 my @files = `find samples/ -maxdepth 1 -name '*.sql' | sort`;
 chomp(@files);
+my $exit = 0;
 
 foreach my $f (@files)
 {
@@ -22,6 +23,7 @@ foreach my $f (@files)
 		} else {
 			print "\ttest failed!!!\n";
 			print @diff;
+			$exit = 1;
 		}
 	}
 	unlink("/tmp/output.sql");
@@ -48,9 +50,10 @@ foreach my $f (@files)
 		} else {
 			print "\ttest failed!!!\n";
 			print @diff;
+			$exit = 1;
 		}
 	}
 	unlink("/tmp/output.sql");
 }
 
-
+exit $exit;

--- a/regress_test.pl
+++ b/regress_test.pl
@@ -1,5 +1,6 @@
 my @files = `find samples/ -maxdepth 1 -name '*.sql' | sort`;
 chomp(@files);
+my $pg_format = $ENV{PG_FORMAT} // './pg_format'; # set to 'pg_format' to test installed binary in /usr/bin
 my $exit = 0;
 
 foreach my $f (@files)


### PR DESCRIPTION
While adding a regress_test.pl run to the Debian package, I noticed that the test result isn't actually used as exit code. Also, I needed a way to tell it to run on /usr/bin/pg_format instead of ./pg_format.
Thanks for considering.