### PR TITLE
Fix test breakage with rcfile

### DIFF
--- a/lib/pgFormatter/CLI.pm
+++ b/lib/pgFormatter/CLI.pm
@@ -199,6 +199,7 @@ Options:
     -B | --comma-break    : in insert statement, add a newline after each comma.
     -c | --config FILE    : use a configuration file. Default is to not use
                             configuration file or ~/.pg_format if it exists.
+                            Set to empty string to prevent reading ~/.pg_format.
     -C | --wrap-comment   : with --wrap-limit, apply reformatting to comments.
     -d | --debug          : enable debug mode. Disabled by default.
     -e | --comma-end      : in a parameters list, end with the comma (default)
@@ -323,7 +324,7 @@ sub get_command_line_args
 
     $cfg{ 'config' }        //= "$ENV{HOME}/.pg_format";
 
-    if (-f $cfg{ 'config' })
+    if ( $cfg{ 'config' } ne '' && -f $cfg{ 'config' } )
     {
         open(my $cfh, '<', $cfg{ 'config' }) or die "ERROR: can not read file $cfg{ 'config' }\n";
         while (my $line = <$cfh>)

--- a/lib/pgFormatter/CLI.pm
+++ b/lib/pgFormatter/CLI.pm
@@ -66,8 +66,8 @@ sub run {
     $self->logmsg( 'DEBUG', 'Beautifying' );
     $self->beautify();
     if ($self->{'wrap_limit'}) {
-	    $self->logmsg( 'DEBUG', 'Wrap query' );
-	    $self->wrap_lines($self->{'wrap_comment'});
+            $self->logmsg( 'DEBUG', 'Wrap query' );
+            $self->wrap_lines($self->{'wrap_comment'});
     }
     $self->logmsg( 'DEBUG', 'Writing output' );
     $self->save_output();
@@ -116,8 +116,8 @@ sub beautify {
     $beautifier->anonymize() if $self->{ 'cfg' }->{ 'anonymize' };
     $beautifier->beautify();
     if ($self->{ 'cfg' }->{ 'wrap-limit' }) {
-	    $self->logmsg( 'DEBUG', 'Wrap query' );
-	    $beautifier->wrap_lines($self->{ 'cfg' }->{ 'wrap-comment' });
+            $self->logmsg( 'DEBUG', 'Wrap query' );
+            $beautifier->wrap_lines($self->{ 'cfg' }->{ 'wrap-comment' });
     }
 
     $self->{ 'ready' } = $beautifier->content();
@@ -139,7 +139,7 @@ sub save_output {
         $self->logmsg( 'DEBUG', 'Formatted SQL queries will be written to stdout' );
         open $fh, '>', $self->{ 'cfg' }->{ 'output' };
     } else {  
-    	$fh = \*STDOUT;
+        $fh = \*STDOUT;
     }
     print $fh $self->{ 'ready' };
     close $fh;
@@ -289,11 +289,11 @@ sub get_command_line_args
         'wrap-comment|C!',
         'debug|d!',
         'comma-end|e!',
-	'format|F=s',
+        'format|F=s',
         'nogrouping|g!',
         'help|h!',
         'function-case|f=i',
-	'no-extra-line|L!',
+        'no-extra-line|L!',
         'maxlength|m=i',
         'nocomment|n!',
         'numbering|N!',
@@ -325,23 +325,23 @@ sub get_command_line_args
 
     if (-f $cfg{ 'config' })
     {
-	open(my $cfh, '<', $cfg{ 'config' }) or die "ERROR: can not read file $cfg{ 'config' }\n";
-	while (my $line = <$cfh>)
-	{
-	    chomp($line);
-	    next if ($line !~ /^[a-z]/);
-	    if ($line =~ /^([^\s=]+)\s*=\s*([^\s]+)/)
-	    {
-		# do not override command line arguments
-		next if (defined $cfg{ lc($1) });
+        open(my $cfh, '<', $cfg{ 'config' }) or die "ERROR: can not read file $cfg{ 'config' }\n";
+        while (my $line = <$cfh>)
+        {
+            chomp($line);
+            next if ($line !~ /^[a-z]/);
+            if ($line =~ /^([^\s=]+)\s*=\s*([^\s]+)/)
+            {
+                # do not override command line arguments
+                next if (defined $cfg{ lc($1) });
 
-		if ($1 eq 'comma' || $1 eq 'format') {
-		    $cfg{ lc($1) } = lc($2);
-		} else {
-		    $cfg{ lc($1) } = $2;
-	        }
-	    }
-	}
+                if ($1 eq 'comma' || $1 eq 'format') {
+                    $cfg{ lc($1) } = lc($2);
+                } else {
+                    $cfg{ lc($1) } = $2;
+                }
+            }
+        }
     }
 
     # Set default configuration
@@ -413,7 +413,7 @@ sub validate_args {
 
    if ($self->{ 'cfg' }->{ 'inplace' } and $self->{ 'cfg' }->{ 'input' } ne '-')
    {
-	$self->{ 'cfg' }->{ 'output' } = $self->{ 'cfg' }->{ 'input' };
+        $self->{ 'cfg' }->{ 'output' } = $self->{ 'cfg' }->{ 'input' };
    }
 
     return;

--- a/t/02_regress.t
+++ b/t/02_regress.t
@@ -18,7 +18,7 @@ foreach my $f (@files)
 	$opt = "-f 2 -u 2 -U 2 " if ($f =~ m#/ex60.sql$#);
 	$opt = "--comma-break -U 2" if ($f =~ m#/ex57.sql$#);
 	$opt = "--keyword-case 2 --function-case 1 --comma-start --wrap-after 1 --wrap-limit 40 --tabs --spaces 4 " if ($f =~ m#/ex58.sql$#);
-	my $cmd = "./pg_format $opt -u 2 $f >/tmp/output.sql";
+	my $cmd = "$pg_format $opt -u 2 $f >/tmp/output.sql";
 	`$cmd`;
 	$f =~ s/test-files\//test-files\/expected\//;
 	if (lc($ARGV[0]) eq 'update') {

--- a/t/02_regress.t
+++ b/t/02_regress.t
@@ -1,6 +1,7 @@
-use Test::Simple tests => 61;
+use Test::Simple tests => 62;
 
 my $ret = `perl -I. -wc pg_format 2>&1`;
+ok( $? == 0, "pg_format compiles OK" ) or exit $?;
 
 my @files = `find t/test-files/ -maxdepth 1 -name '*.sql' | sort`;
 chomp(@files);

--- a/t/02_regress.t
+++ b/t/02_regress.t
@@ -18,7 +18,7 @@ foreach my $f (@files)
 	$opt = "-f 2 -u 2 -U 2 " if ($f =~ m#/ex60.sql$#);
 	$opt = "--comma-break -U 2" if ($f =~ m#/ex57.sql$#);
 	$opt = "--keyword-case 2 --function-case 1 --comma-start --wrap-after 1 --wrap-limit 40 --tabs --spaces 4 " if ($f =~ m#/ex58.sql$#);
-	my $cmd = "$pg_format $opt -u 2 $f >/tmp/output.sql";
+	my $cmd = "$pg_format $opt -u 2 -c '' $f >/tmp/output.sql";
 	`$cmd`;
 	$f =~ s/test-files\//test-files\/expected\//;
 	if (lc($ARGV[0]) eq 'update') {

--- a/t/02_regress.t
+++ b/t/02_regress.t
@@ -1,7 +1,7 @@
 use Test::Simple tests => 62;
 
-my $ret = `perl -I. -wc pg_format 2>&1`;
-ok( $? == 0, "pg_format compiles OK" ) or exit $?;
+my $ret = `perl -I. -wc ./pg_format 2>&1`;
+ok( $? == 0, "./pg_format compiles OK" ) or exit $?;
 
 my @files = `find t/test-files/ -maxdepth 1 -name '*.sql' | sort`;
 chomp(@files);


### PR DESCRIPTION
The regression tests break if the user has a configuration file in ~/.pg_config which sets some options to non-default values. This PR fixes that (plus some other, smaller issues, I suggest reviewing commit by commit).