### PR TITLE
Add --no-rcfile / -X option

### DIFF
--- a/lib/pgFormatter/CLI.pm
+++ b/lib/pgFormatter/CLI.pm
@@ -105,6 +105,7 @@ sub beautify {
     $args{ 'wrap_comment' } = $self->{ 'cfg' }->{ 'wrap-comment' };
     $args{ 'no_extra_line' }= $self->{ 'cfg' }->{ 'no-extra-line' };
     $args{ 'config' }       = $self->{ 'cfg' }->{ 'config' };
+    $args{ 'no_rcfile' }    = $self->{ 'cfg' }->{ 'no-rcfile' };
     $args{ 'inplace' }      = $self->{ 'cfg' }->{ 'inplace' };
 
     if ($self->{ 'query' } && ($args{ 'maxlength' } && length($self->{ 'query' }) > $args{ 'maxlength' })) {
@@ -199,7 +200,8 @@ Options:
     -B | --comma-break    : in insert statement, add a newline after each comma.
     -c | --config FILE    : use a configuration file. Default is to not use
                             configuration file or ~/.pg_format if it exists.
-                            Set to empty string to prevent reading ~/.pg_format.
+    -X | --no-rcfile      : do not read ~/.pg_format automatically. The
+                            --config / -c option overrides it.
     -C | --wrap-comment   : with --wrap-limit, apply reformatting to comments.
     -d | --debug          : enable debug mode. Disabled by default.
     -e | --comma-end      : in a parameters list, end with the comma (default)
@@ -287,6 +289,7 @@ sub get_command_line_args
         'comma-start|b!',
         'comma-break|B!',
         'config|c=s',
+        'no-rcfile|X!',
         'wrap-comment|C!',
         'debug|d!',
         'comma-end|e!',
@@ -322,9 +325,11 @@ sub get_command_line_args
         exit 0;
     }
 
-    $cfg{ 'config' }        //= "$ENV{HOME}/.pg_format";
+    if ( !$cfg{ 'no-rcfile' } ) {
+        $cfg{ 'config' } //= "$ENV{HOME}/.pg_format";
+    }
 
-    if ( $cfg{ 'config' } ne '' && -f $cfg{ 'config' } )
+    if ( defined $cfg{ 'config' } && -f $cfg{ 'config' } )
     {
         open(my $cfh, '<', $cfg{ 'config' }) or die "ERROR: can not read file $cfg{ 'config' }\n";
         while (my $line = <$cfh>)

--- a/t/02_regress.t
+++ b/t/02_regress.t
@@ -20,7 +20,7 @@ foreach my $f (@files)
 	$opt = "-f 2 -u 2 -U 2 " if ($f =~ m#/ex60.sql$#);
 	$opt = "--comma-break -U 2" if ($f =~ m#/ex57.sql$#);
 	$opt = "--keyword-case 2 --function-case 1 --comma-start --wrap-after 1 --wrap-limit 40 --tabs --spaces 4 " if ($f =~ m#/ex58.sql$#);
-	my $cmd = "$pg_format $opt -u 2 -c '' $f >/tmp/output.sql";
+	my $cmd = "$pg_format $opt -u 2 -X $f >/tmp/output.sql";
 	`$cmd`;
 	$f =~ s/test-files\//test-files\/expected\//;
 	if (lc($ARGV[0]) eq 'update') {

--- a/t/02_regress.t
+++ b/t/02_regress.t
@@ -1,6 +1,6 @@
 use Test::Simple tests => 62;
 
-my $pg_format = $ENV{PG_FORMAT} // './pg_format'; # set to 'pg_format' to test installed binary in /usr/bin
+my $pg_format = $ENV{PG_FORMAT} // './pg_format'; # set to the full path to 'pg_format' to test installed binary in /usr/bin
 
 my $ret = `perl -I. -wc $pg_format 2>&1`;
 ok( $? == 0, "$pg_format compiles OK" ) or exit $?;


### PR DESCRIPTION
As outlined in https://github.com/darold/pgFormatter/pull/206#issuecomment-666392540. Note: I wrote no tests for this functionality (apparently the `--config` / `-c` option has no tests, either).