### PR TITLE
Fix formatting for C functions with obj_file and link_symbol

### DIFF
--- a/lib/pgFormatter/Beautify.pm
+++ b/lib/pgFormatter/Beautify.pm
@@ -264,6 +264,13 @@ sub query
 			    $i++;
 		    }
 	    }
+	    # C function language with AS obj_file, link_symbol
+	    elsif ($language =~ /^c$/i) {
+		    if ($temp_content[$j] =~ s/AS ('[^\']+')\s*,\s*('[^\']+')/AS CODEPARTB${i}CODEPARTB/i) {
+			    push(@{ $self->{ 'placeholder_values' } }, "$1, $2");
+			    $i++;
+		    }
+	    }
             # if the function language is not SQL or PLPGSQL
 	    elsif ($language !~ /^(?:plpg)?sql$/)
 	    {


### PR DESCRIPTION
This patch fixes the formatting for CREATE FUNCTION statements for
C functions of the following form:

CREATE OR REPLACE FUNCTION f() RETURNS BOOL AS '/foo','bar' LANGUAGE C;

formatting without patch:

CREATE OR REPLACE FUNCTION f ()
  RETURNS BOOL
  AS '/foo'
,
  'bar'
  LANGUAGE C;

formatting with patch:

CREATE OR REPLACE FUNCTION f ()
  RETURNS BOOL
  AS '/foo', 'bar'
  LANGUAGE C;