### PR TITLE
Replace deprecated TG_RELNAME with TG_TABLE_NAME

### DIFF
--- a/t/pg-test-files/expected/triggers.sql
+++ b/t/pg-test-files/expected/triggers.sql
@@ -770,7 +770,7 @@ CREATE FUNCTION trigtest ()
     RETURNS TRIGGER
     AS $$
 BEGIN
-    RAISE notice '% % % %', TG_RELNAME, TG_OP, TG_WHEN, TG_LEVEL;
+    RAISE notice '% % % %', TG_TABLE_NAME, TG_OP, TG_WHEN, TG_LEVEL;
     RETURN new;
 END;
 $$
@@ -864,7 +864,6 @@ BEGIN
     RAISE NOTICE 'TG_LEVEL: %', TG_level;
     RAISE NOTICE 'TG_OP: %', TG_op;
     RAISE NOTICE 'TG_RELID::regclass: %', relid;
-    RAISE NOTICE 'TG_RELNAME: %', TG_relname;
     RAISE NOTICE 'TG_TABLE_NAME: %', TG_table_name;
     RAISE NOTICE 'TG_TABLE_SCHEMA: %', TG_table_schema;
     RAISE NOTICE 'TG_NARGS: %', TG_nargs;
@@ -1117,7 +1116,7 @@ BEGIN
         END IF;
         argstr := argstr || TG_argv[i];
     END LOOP;
-    RAISE notice '% % % % (%)', TG_RELNAME, TG_WHEN, TG_OP, TG_LEVEL, argstr;
+    RAISE notice '% % % % (%)', TG_TABLE_NAME, TG_WHEN, TG_OP, TG_LEVEL, argstr;
     IF TG_LEVEL = 'ROW' THEN
         IF TG_OP = 'INSERT' THEN
             RAISE NOTICE 'NEW: %', NEW;

--- a/t/pg-test-files/sql/triggers.sql
+++ b/t/pg-test-files/sql/triggers.sql
@@ -373,7 +373,7 @@ create table trigtest2 (i int references trigtest(i) on delete cascade);
 
 create function trigtest() returns trigger as $$
 begin
-	raise notice '% % % %', TG_RELNAME, TG_OP, TG_WHEN, TG_LEVEL;
+	raise notice '% % % %', TG_TABLE_NAME, TG_OP, TG_WHEN, TG_LEVEL;
 	return new;
 end;$$ language plpgsql;
 
@@ -438,7 +438,6 @@ begin
 	raise NOTICE 'TG_LEVEL: %', TG_level;
 	raise NOTICE 'TG_OP: %', TG_op;
 	raise NOTICE 'TG_RELID::regclass: %', relid;
-	raise NOTICE 'TG_RELNAME: %', TG_relname;
 	raise NOTICE 'TG_TABLE_NAME: %', TG_table_name;
 	raise NOTICE 'TG_TABLE_SCHEMA: %', TG_table_schema;
 	raise NOTICE 'TG_NARGS: %', TG_nargs;
@@ -609,7 +608,7 @@ begin
         argstr := argstr || TG_argv[i];
     end loop;
 
-    raise notice '% % % % (%)', TG_RELNAME, TG_WHEN, TG_OP, TG_LEVEL, argstr;
+    raise notice '% % % % (%)', TG_TABLE_NAME, TG_WHEN, TG_OP, TG_LEVEL, argstr;
 
     if TG_LEVEL = 'ROW' then
         if TG_OP = 'INSERT' then


### PR DESCRIPTION
The TG_RELNAME variable which is used in the test schema has been
deprecated since PostgreSQL 8.2 and replaced with TG_TABLE_NAME.

Also remove a couple of references to TG_RELNAME where there also is a
reference to TG_TABLE_NAME.

See PostgreSQL commit [3a9ae3d2068334bbd0e54efaa729e7590994ccc8](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=3a9ae3d2068334bbd0e54efaa729e7590994ccc8).