### PR TITLE
Adding example for regular expression preserving the url

### DIFF
--- a/README
+++ b/README
@@ -322,6 +322,16 @@ HINTS
             pg_format samples/ex9.sql -p '<<(?:.*)?>>'
 
     will not format the bit-shift like operators.
+    
+    If you would like to wrap queries after 60 characters (-w 60) and to 
+    apply that limit to comments as well (-C), then the url may get 
+    wrapped. If you would prefer not to wrap url, you can use a regular
+    expression like the one found at https://stackoverflow.com/a/3809435/
+    to avoid wrapping urls.  For example:
+
+            pg_format samples/ex62.sql -C -w 60 -p 'https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)'
+
+    will wrap the queries and the comments, but not the urls.
 
   Prevent dynamic code formatting
     By default pgFormatter takes all code between single quote as string

--- a/README
+++ b/README
@@ -324,8 +324,8 @@ HINTS
     will not format the bit-shift like operators.
     
     If you would like to wrap queries after 60 characters (-w 60) and to 
-    apply that limit to comments as well (-C), then the url may get 
-    wrapped. If you would prefer not to wrap url, you can use a regular
+    apply that limit to comments as well (-C), then urls in comments may get 
+    wrapped. If you would prefer not to wrap urls, you can use a regular
     expression like the one found at https://stackoverflow.com/a/3809435/
     to avoid wrapping urls.  For example:
 

--- a/t/test-files/ex62.sql
+++ b/t/test-files/ex62.sql
@@ -1,0 +1,3 @@
+-- test placeholder: perl pg_format samples/ex62.sql -w 60 -C -p 'https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)'
+
+-- This code simply contains a long url in a comment. https://github.com/aubertc/pgFormatter/blob/master/t/test-files/ex62.sql

--- a/t/test-files/expected/ex62.sql
+++ b/t/test-files/expected/ex62.sql
@@ -1,0 +1,6 @@
+-- test placeholder: perl pg_format samples/ex62.sql -w 60 -C
+-- -p
+-- 'https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z
+-- 0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)'
+--  This code simply contains a long url in a comment.
+-- https://github.com/aubertc/pgFormatter/blob/master/t/test-files/ex62.sql


### PR DESCRIPTION
I hope I followed your guidelines. I'm simply adding an example that I believe useful on how to avoid wrapping urls in comments when wrapping the code and the comments.