### PR TITLE
Fixed formatting words with CREATE prefix or DROP suffix

### DIFF
--- a/lib/pgFormatter/Beautify.pm
+++ b/lib/pgFormatter/Beautify.pm
@@ -1113,7 +1113,7 @@ sub beautify
             $self->{ '_is_in_publication' } = 1;
         } elsif ($token =~ /^CREATE$/i && $self->_next_token =~ /^CONVERSION$/i) {
 	    $self->{ '_is_in_conversion' } = 1;
-        } elsif ($token =~ /^CREATE|DROP$/i && $self->_next_token =~ /^OPERATOR$/i) {
+        } elsif ($token =~ /^(CREATE|DROP)$/i && $self->_next_token =~ /^OPERATOR$/i) {
 	    $self->{ '_is_in_operator' } = 1;
             $self->{ '_is_in_drop' } = 1 if ($token =~ /^DROP$/i);
         } elsif ($token =~ /^ALTER$/i) {


### PR DESCRIPTION
This PR fixes #254

Example:
```sql
SELECT create_foo
```

Before this fix this raised a deadly warning:
```
$ echo SELECT create_foo | ./pg_format
Uncaught exception: Deadly warning: Use of uninitialized value in pattern match (m//) at /Users/martin/Downloads/pgFormatter-master/lib/pgFormatter/Beautify.pm line 1116, <STDIN> line 1.
 at ./pg_format line 27, <STDIN> line 1.
	main::__ANON__('Use of uninitialized value in pattern match (m//) at /Users/m...') called at /Users/martin/Downloads/pgFormatter-master/lib/pgFormatter/Beautify.pm line 1104
	pgFormatter::Beautify::beautify('pgFormatter::Beautify=HASH(0x7f809eb3d460)') called at /Users/martin/Downloads/pgFormatter-master/lib/pgFormatter/CLI.pm line 136
	pgFormatter::CLI::beautify('pgFormatter::CLI=HASH(0x7f80ae80b6e8)') called at /Users/martin/Downloads/pgFormatter-master/lib/pgFormatter/CLI.pm line 67
	pgFormatter::CLI::run('pgFormatter::CLI=HASH(0x7f80ae80b6e8)') called at ./pg_format line 49
 at ./pg_format line 19, <STDIN> line 1.
	main::__ANON__('Deadly warning: Use of uninitialized value in pattern match (...') called at /System/Library/Perl/5.18/Carp.pm line 101
	Carp::confess('Deadly warning: Use of uninitialized value in pattern match (...') called at ./pg_format line 27
	main::__ANON__('Use of uninitialized value in pattern match (m//) at /Users/m...') called at /Users/martin/Downloads/pgFormatter-master/lib/pgFormatter/Beautify.pm line 1104
	pgFormatter::Beautify::beautify('pgFormatter::Beautify=HASH(0x7f809eb3d460)') called at /Users/martin/Downloads/pgFormatter-master/lib/pgFormatter/CLI.pm line 136
	pgFormatter::CLI::beautify('pgFormatter::CLI=HASH(0x7f80ae80b6e8)') called at /Users/martin/Downloads/pgFormatter-master/lib/pgFormatter/CLI.pm line 67
	pgFormatter::CLI::run('pgFormatter::CLI=HASH(0x7f80ae80b6e8)') called at ./pg_format line 49
```

After this fix:
```$ echo SELECT create_foo | ./pg_format
SELECT
    create_foo
```