### PR TITLE
Correctly format casts to quoted types

### DIFF
--- a/lib/pgFormatter/Beautify.pm
+++ b/lib/pgFormatter/Beautify.pm
@@ -2796,7 +2796,7 @@ sub _add_token
 	{
 	    if ($token ne ')'
                                             && defined($last_token)
-                                            && $last_token ne '::' 
+                                            && $last_token !~ '::$'
                                             && $last_token ne '[' 
 					    && ($token ne '(' || !$self->_is_function( $last_token ) || $self->{ '_is_in_type' })
                 )
@@ -2892,7 +2892,7 @@ sub _add_token
     # Be sure that we not going to modify a constant
     if ($self->{ '_is_in_create' } < 2 and $token !~ /^[E]*'.*'$/)
     {
-	    @cast = split(/::/, $token);
+	    @cast = split(/::/, $token, -1);
 	    $token = shift(@cast) if ($#cast >= 0);
 	    @next_cast = split(/::/, $next_token);
 	    $next_token = shift(@next_cast) if ($#next_cast >= 0);

--- a/t/pg-test-files/expected/hash_func.sql
+++ b/t/pg-test-files/expected/hash_func.sql
@@ -105,7 +105,7 @@ SELECT
     hashcharextended(v, 0)::bit(32) AS extended0,
     hashcharextended(v, 1)::bit(32) AS extended1
 FROM (
-    VALUES (NULL "char"),
+    VALUES (NULL::"char"),
         ('1'),
         ('x'),
         ('X'),

--- a/t/test-files/ex66.sql
+++ b/t/test-files/ex66.sql
@@ -1,0 +1,3 @@
+SELECT col::"text" FROM tab;
+
+ALTER TABLE tab ALTER COLUMN col TYPE "schema"."dataType" USING col::text::"schema"."dataType";

--- a/t/test-files/expected/ex66.sql
+++ b/t/test-files/expected/ex66.sql
@@ -1,0 +1,9 @@
+SELECT
+    col::"text"
+FROM
+    tab;
+
+ALTER TABLE tab
+    ALTER COLUMN col TYPE "schema"."dataType"
+    USING col::text::"schema"."dataType";
+


### PR DESCRIPTION
When encountering a construct like [ col::"text" ], the input is
tokenized into [ col:: ] [ "text" ], and then when those tokens are
printed the final cast is omitted from the first token and it ends up
as [ col "text" ], which produces a syntax error.  Fix this by
outputting the trailing "::" from the first token and omitting the
space between tokens when the previous token ends with "::".

Theoretically this could be fixed by changing the tokenization so that
[ col::"text" ] is generated as a single token, but that seemed like
it was much more likely to introduce bugs elsewhere or require
significant changes to the tokenizing logic.

The hash_func.sql had to be updated because it uses this construct.
The formatted code from before this change produces a syntax error in
my local Postgres (v12.4), so this shouldn't affect working code.