### PR TITLE
feat: allow to pass multiple files when using --inplace

### DIFF
--- a/README
+++ b/README
@@ -19,7 +19,7 @@ DESCRIPTION
 
     Arguments:
 
-        file.sql can be a file or use - to read query from stdin.
+        file.sql can be a file, multiple files or use - to read query from stdin.
 
         Returning the SQL formatted to stdout or into a file specified with
         the -o | --output option.
@@ -42,7 +42,7 @@ DESCRIPTION
         -g | --nogrouping     : add a newline between statements in transaction
                                 regroupement. Default is to group statements.
         -h | --help           : show this message and exit.
-        -i | --inplace        : override input file with formatted content.
+        -i | --inplace        : override input files with formatted content.
         -k | --keep-newline   : preserve empty line in plpgsql code.
         -L | --no-extra-line  : do not add an extra empty line at end of the output.
         -m | --maxlength SIZE : maximum length of a query, it will be cutted above
@@ -237,7 +237,7 @@ HINTS
     If you use the interactive mode you have to type `ctrl+d` after typing
     your SQL statement to format to end the typing.
 
-            $ pg_format 
+            $ pg_format
             select * from customers;
             < ctrl+d >
 

--- a/doc/pg_format.pod
+++ b/doc/pg_format.pod
@@ -21,7 +21,7 @@ Usage: pg_format [options] file.sql
 
 Arguments:
 
-    file.sql can be a file or use - to read query from stdin.
+    file.sql can be a file, multiple files or use - to read query from stdin.
 
     Returning the SQL formatted to stdout or into a file specified with
     the -o | --output option.
@@ -44,7 +44,7 @@ Options:
     -g | --nogrouping     : add a newline between statements in transaction
                             regroupement. Default is to group statements.
     -h | --help           : show this message and exit.
-    -i | --inplace        : override input file with formatted content.
+    -i | --inplace        : override input files with formatted content.
     -k | --keep-newline   : preserve empty line in plpgsql code.
     -L | --no-extra-line  : do not add an extra empty line at end of the output.
     -m | --maxlength SIZE : maximum length of a query, it will be cutted above
@@ -136,7 +136,7 @@ If you have docker installed you can build a pgFormatter image using:
 
 	docker build -t darold.net/pgformatter .
 
-then just use it as 
+then just use it as
 
 	echo file.sql | docker run --rm -a stdin -a stdout -i darold.net/pgformatter -
 
@@ -148,11 +148,11 @@ then just use it as
 This option can be used to set number of column after which lists must be
 wrapped. By default pgFormatter puts every item on its own line. This format
 applies to SELECT and FROM list. For example the following query:
-    
+
     SELECT a, b, c, d FROM t_1, t_2, t3 WHERE a = 10 AND b = 10;
-    
+
 will be formatted into with -W 4:
-    
+
     SELECT a, b, c, d
     FROM t_1, t_2, t3
     WHERE a = 10
@@ -252,7 +252,7 @@ format through stdin.
 If you use the interactive mode you have to type `ctrl+d` after typing your
 SQL statement to format to end the typing.
 
-	$ pg_format 
+	$ pg_format
 	select * from customers;
 	< ctrl+d >
 
@@ -340,9 +340,9 @@ instruct pgFormatter to keep some part of the query untouched. For example:
 	pg_format samples/ex9.sql -p '<<(?:.*)?>>'
 
 will not format the bit-shift like operators.
-    
-If you would like to wrap queries after 60 characters (-w 60) and to 
-apply that limit to comments as well (-C), then urls in comments may get 
+
+If you would like to wrap queries after 60 characters (-w 60) and to
+apply that limit to comments as well (-C), then urls in comments may get
 wrapped. If you would prefer not to wrap urls, you can use a regular
 expression to avoid wrapping urls.  For example:
 


### PR DESCRIPTION
This pr allows to pass multiple files as arguments to `pg_format` CLI.

## Why?

With multiple files (+700), executing them one by one may be very slow (+100s).
Using concurrency (N=100) improves speed a bit (~30s).

However, with passing multiple files as arguments the speed can be improved even more (with concurrency N=100 it improved to ~15s).

