### PR TITLE
Expand web capabilities of the app

### DIFF
--- a/README
+++ b/README
@@ -401,6 +401,12 @@ HINTS
     custom file content. You have to look at the generated HTML output to
     get the default CSS code used.
 
+  Using pgFormatter as an API
+    You may use pgFormatter as an API by setting the 'Accept' HTTP header to
+    value 'application/json' when calling it as a CGI app. In case you do not
+    want to enable this feature, set `$self->{ 'enable_api' } = 0` in the
+    `set_config` sub of CGI.pm.
+
 AUTHORS
     pgFormatter is an original work from Gilles Darold with major code
     refactoring by Hubert depesz Lubaczewski.

--- a/README
+++ b/README
@@ -8,7 +8,8 @@ DESCRIPTION
 
     pgFormatter can work as a console program or as a CGI. It will
     automatically detect its environment and format output as text or as
-    HTML following the context.
+    HTML following the context. It can also return a JSON-formatted response
+    if used as CGI with 'Accept: application/json'.
 
     Keywords highlighting will only be available in CGI context.
 

--- a/cgi.Dockerfile
+++ b/cgi.Dockerfile
@@ -1,0 +1,27 @@
+FROM nginx:latest
+RUN apt-get clean && apt-get update && apt-get install -y spawn-fcgi fcgiwrap libcgi-pm-perl libjson-perl libdata-dump-perl && rm -rf /var/lib/{apt,dpkg}
+RUN sed -i 's/www-data/nginx/g' /etc/init.d/fcgiwrap
+RUN chown nginx:nginx /etc/init.d/fcgiwrap
+RUN <<EOR
+cat > /etc/nginx/conf.d/default.conf <<EOF
+server {
+        listen 8080 default_server;
+        root /var/www/html;
+        index index.html index.htm;
+        server_name _;
+	location / {
+	  gzip off;
+	  fastcgi_pass  unix:/var/run/fcgiwrap.socket;
+	  include /etc/nginx/fastcgi_params;
+	  fastcgi_param SCRIPT_FILENAME  /app/pg_format;
+	  fastcgi_param SERVER_NAME \$http_host;
+	}
+}
+EOF
+EOR
+WORKDIR /app
+ADD pg_format /app
+ADD lib /app/lib
+EXPOSE 8080
+CMD /etc/init.d/fcgiwrap start \
+    && nginx -g 'daemon off;'

--- a/lib/pgFormatter/CGI.pm
+++ b/lib/pgFormatter/CGI.pm
@@ -59,7 +59,7 @@ sub run {
     $self->get_cgi();
     if ($self->{ 'cgi' }->Accept( "text/html" )) {
       $self->run_webpage();
-    } elsif ($self->{ 'cgi' }->Accept( "application/json" )) {
+    } elsif ($self->{ 'cgi' }->Accept( "application/json" ) && $self->{ 'enable_api' }) {
       $self->run_api();
     } else {
       $self->print_error();
@@ -139,6 +139,7 @@ sub set_config {
     $self->{ 'outdir' }       = '';
     $self->{ 'help' }         = '';
     $self->{ 'version' }      = '';
+    $self->{ 'enable_api' }   = 1;
     $self->{ 'debug' }        = 0;
     $self->{ 'content' }      = '';
     $self->{ 'original_content' }      = '';


### PR DESCRIPTION
Salut Gilles,

I just added a JSON output capability to your project to be able to use it as a service. In order to leverage this feature, you just need to call the website as follows:

```bash
curl --no-progress-meter \
  https://your.host -X POST -H 'Content-type: application/json' \
  -d '{"content": "SELECT 1;"}' -H "Accept: application/json" | jq -r '.formatted' 
SELECT
    1;


curl http://your.host -X POST -H 'Content-type: application/json' \
  -d '{"content": "SELECT 1;"}' -H "Accept: application/json";
{"formatted":"SELECT\n    1;\n\n"}
```

This makes it easily integrated to other services and is the purpose why I use that.

I also included a Dockerfile for CGI to easily test that feature.

Build and run it using:

```bash
docker build -t pg_formatter -f cgi.Dockerfile .
docker run -p 8080 --name pg_formatter --rm pg_formatter
```

You may disable this feature by setting the configuration parameter "enable_api" to 0, similar to how you enable or disable debug.

I hope you find that useful and merge it :)

à la prochaine