### PR TITLE
Fixing indentation for SELECT statements in CTEs that use Postgres functions

### DIFF
--- a/t/02_regress.t
+++ b/t/02_regress.t
@@ -1,4 +1,4 @@
-use Test::Simple tests => 76;
+use Test::Simple tests => 77;
 use File::Temp qw/ tempfile /;
 
 my $pg_format = $ENV{PG_FORMAT} // './pg_format'; # set to the full path to 'pg_format' to test installed binary in /usr/bin

--- a/t/test-files/ex75.sql
+++ b/t/test-files/ex75.sql
@@ -1,0 +1,4 @@
+WITH example AS (SELECT a, b FROM tablename),
+example2 AS (SELECT COALESCE(a, 1) AS a, b FROM example)
+INSERT INTO example3 (a, b)
+SELECT a, b FROM example

--- a/t/test-files/expected/ex75.sql
+++ b/t/test-files/expected/ex75.sql
@@ -1,0 +1,19 @@
+WITH example AS (
+    SELECT
+        a,
+        b
+    FROM
+        tablename
+),
+example2 AS (
+    SELECT
+        COALESCE(a, 1) AS a,
+        b
+    FROM
+        example)
+INSERT INTO example3 (a, b)
+SELECT
+    a,
+    b
+FROM
+    example


### PR DESCRIPTION
When using postgres functions inside CTEs, sometimes this can cause indentation errors. 

For instance
```
WITH example AS (
    SELECT
        a,
        b
    FROM
        tablename
),
example2 AS (
    SELECT
        COALESCE(a, 1) AS a,
    b -- the indentation drops here when it should not
FROM
    example)
INSERT INTO example3 (a, b)
SELECT
    a,
    b
FROM
    example
```
Should be formatted as
```
WITH example AS (
    SELECT
        a,
        b
    FROM
        tablename
),
example2 AS (
    SELECT
        COALESCE(a, 1) AS a,
        b -- the indentation drops here when it should not
    FROM
        example)
INSERT INTO example3 (a, b)
SELECT
    a,
    b
FROM
    example
```
But it is not. 

This PR fixes this, and adds a test :) 