### PR TITLE
Fix Possible-precedence-problem warnings

### DIFF
--- a/lib/pgFormatter/Beautify.pm
+++ b/lib/pgFormatter/Beautify.pm
@@ -546,7 +546,7 @@ sub highlight_code {
 			&& $next_token eq '('
 		)
 		|| (   !$self->_is_keyword( $token, $next_token, $last_token )
-			&& !$next_token eq '('
+			&& $next_token ne '('
 			&& $token ne '('
 			&& !$self->_is_comment($token) )
 	  )
@@ -3969,7 +3969,7 @@ sub _add_token {
 				and uc($last_token) ne 'CREATE'
 			)
 			or (    !$self->_is_keyword( $token, $next_token, $last_token )
-				and !$next_token eq '('
+				and $next_token ne '('
 				and $token ne '('
 				and !$self->_is_comment($token) )
 		  )


### PR DESCRIPTION
This is a attempt to address "Possible precedence problem" warnings generated when running under Perl v5.41.4 and later. The issue raised is described here: <https://perldoc.perl.org/5.41.4/perldiag#Possible-precedence-problem-between-!-and-%25s>

The PR changes two places in `Beautify.pm`, switching from `!$next_token eq '('` to `$next_token ne '('`.

Closes #363 


