### PR TITLE
Fix precedence errors so it works under perl 5.42

### DIFF
--- a/lib/pgFormatter/Beautify.pm
+++ b/lib/pgFormatter/Beautify.pm
@@ -495,7 +495,7 @@ sub highlight_code
     # lowercase/uppercase known functions or words followed by an open parenthesis
     # if the token is not a keyword, an open parenthesis or a comment
     if (($self->_is_function( $token, $last_token, $next_token ) && $next_token eq '(')
-	    || (!$self->_is_keyword( $token, $next_token, $last_token ) && !$next_token eq '('
+	    || ( !$self->_is_keyword( $token, $next_token, $last_token ) && ($next_token ne '(')
 		    && $token ne '(' && !$self->_is_comment( $token )) ) {
         if ($self->{ 'uc_functions' } == 1) {
             $token = '<span class="kw2_l">' . $token . '</span>';
@@ -3096,7 +3096,7 @@ sub _add_token
         # if the token is not a keyword, an open parenthesis or a comment
         my $fct = $self->_is_function( $token, $last_token, $next_token ) || '';
         if (($fct and $next_token eq '(' and defined $last_token and uc($last_token) ne 'CREATE')
-		or (!$self->_is_keyword( $token, $next_token, $last_token ) and !$next_token eq '('
+		or (!$self->_is_keyword( $token, $next_token, $last_token ) and $next_token ne '('
 				    and $token ne '(' and !$self->_is_comment( $token )) )
 	{
             $token =~ s/$fct/\L$fct\E/i if ( $self->{ 'uc_functions' } == 1 );


### PR DESCRIPTION
This PR fixes the app so that it works under Perl 5.42

Under 5.42, this error happens otherwise:

```
Uncaught exception: Uncaught exception: Possible precedence problem between ! and string eq
```