### PR TITLE
fixes

### DIFF
--- a/lib/pgFormatter/Beautify.pm
+++ b/lib/pgFormatter/Beautify.pm
@@ -2218,7 +2218,7 @@ sub beautify {
 				  if ( !$self->{'wrap_after'} && !$self->{'_is_in_overlaps'} );
 				$self->_add_token($token);
 				$last = $self->_set_last( $token, $last )
-				  if ( $token ne ')' or uc( $self->_next_token ) ne 'AS' );
+				  if ( $token ne ')' or (defined $self->_next_token and uc( $self->_next_token ) ne 'AS') );
 				$self->{'_is_in_explain'} = 0;
 				next;
 			}

--- a/lib/pgFormatter/Beautify.pm
+++ b/lib/pgFormatter/Beautify.pm
@@ -404,6 +404,12 @@ s/AS ('[^\']+')\s*,\s*('[^\']+')/AS CODEPARTB${i}CODEPARTB/is
 	}
 	$self->{'query'} = join( '', @temp_content );
 
+	# replace all inline dollar-quoted constants
+	while ( $self->{'query'} =~ s/(\$\$\S[^\n\r]*?\$\$)/AAKEYWCONST${j}AA/s ) {
+		$self->{'keyword_constant'}{$j} = $1;
+		$j++;
+	}
+
  # Store values of code that must not be changed following the given placeholder
 	if ( $self->{'placeholder'} ) {
 		if ( !$self->{'multiline'} ) {

--- a/t/test-files/expected/ex77.sql
+++ b/t/test-files/expected/ex77.sql
@@ -69,12 +69,5 @@ $$
 LANGUAGE plpgsql;
 
 SELECT
-    throws_ok ($$
-        SELECT
-            * FROM custom_function ('value1', 'value2');
-
-$$,
-'P0001',
-'NULL password for new user: app21_user',
-$e$ NULL PASSWORD FOR new user: app21_user $e$);
+    throws_ok ($$select * from custom_function('value1', 'value2');$$, 'P0001', 'NULL password for new user: app21_user', $e$ NULL PASSWORD FOR new user: app21_user $e$);
 


### PR DESCRIPTION
- **Fix crash on uninitialized variable**
  This commit fixes a crash on uninitialized _next_token in CTE/explain path.
  
  When a closing parenthesis is the last meaningful token in a statement,
  _next_token returns undef. The CTE/explain code path called `uc()` on it
  unconditionally, triggering a `"Use of uninitialized value in uc"` warning
  that the `$SIG{__WARN__}` handler in pg_format promotes to a fatal
  exception.
  
  Add a `defined` guard before the `uc()` call, consistent with the existing patterns here.
  
  Example SQL that triggers the crash:
  ```sql
  \copy (
    SELECT a.id FROM t
  ) TO STDOUT WITH (FORMAT csv)
  ```
  Any query where ')' is the final token while `_is_in_with` or `_is_in_explain` is active will hit this path.
  

- **Preserve inline $$…$$ dollar-quoted strings**
  This commit fixes verbatim string handling of inline `$$…$$` dollar-quoted strings by treating them as constants.
  
  Dollar-quoted string literals like `$$https://example.com$$` were being tokenized as separate `$$` delimiters with the content formatted as SQL; adding spaces, changing keyword case, and breaking the string value.
  

- **tests: update for dollar-quoted strings**
  Dollar-quoted strings are string literals and their contents should be left alone.
  