### PR TITLE
Fix indentation of RETURNING ... INTO statements.

### DIFF
--- a/lib/pgFormatter/Beautify.pm
+++ b/lib/pgFormatter/Beautify.pm
@@ -947,6 +947,7 @@ sub beautify {
 	$self->{'_is_in_between'}              = 0;
 	$self->{'_is_in_materialized'}         = 0;
 	$self->{'_is_closing_function'}        = 0;
+	$self->{'_is_in_returning'}            = 0;
 
 	@{ $self->{'_begin_level'} } = ();
 
@@ -2594,6 +2595,7 @@ sub beautify {
 			$self->{'_is_in_drop_function'}        = 0;
 			$self->{'_current_full_sql_stmt'}      = '';
 			$self->{ '_is_in_return_query' }       = 0;
+			$self->{'_is_in_returning'}            = 0;
 
 			if ( $self->{'_insert_values'} ) {
 				if (    $self->{'_is_in_block'} == -1
@@ -2714,6 +2716,8 @@ sub beautify {
 			$self->{'_is_in_set'} = 1
 			if ( uc($token) eq 'SET'
 				&& $self->{'_current_sql_stmt'} !~ /^(UPDATE|INSERT)$/i );
+				
+			$self->{'_is_in_returning'} = 1 if ( uc($token) eq 'RETURNING' );
 
 			# special cases for create partition statement
 			if (    $token =~ /^VALUES$/i && defined $last
@@ -3763,6 +3767,18 @@ sub beautify {
 
 				if ($self->{'_current_sql_stmt'} eq 'SELECT' and $token =~ /^INTO$/i)
 				{
+					$self->_back( $token, $last );
+					$self->_new_line( $token, $last );
+					# Finally add the token without further condition
+					$self->_add_token( $token, $last );
+					$self->_new_line( $token, $last );
+					$self->_over( $token, $last );
+					next;
+				}
+
+				if ($self->{'_is_in_returning'} and $token =~ /^INTO$/i)
+				{
+					$self->{'_is_in_returning'} = 0;
 					$self->_back( $token, $last );
 					$self->_new_line( $token, $last );
 					# Finally add the token without further condition

--- a/t/pg-test-files/expected/brin.sql
+++ b/t/pg-test-files/expected/brin.sql
@@ -327,7 +327,9 @@ BEGIN
         INSERT INTO brin_summarize
             VALUES (1)
         RETURNING
-            ctid INTO curtid;
+            ctid
+        INTO
+            curtid;
         EXIT
         WHEN curtid > tid '(2, 0)';
     END LOOP;

--- a/t/pg-test-files/expected/fsm.sql
+++ b/t/pg-test-files/expected/fsm.sql
@@ -64,7 +64,9 @@ BEGIN
         INSERT INTO fsm_check_size
             VALUES (num, 'b')
         RETURNING
-            ctid INTO curtid;
+            ctid
+        INTO
+            curtid;
         EXIT
         WHEN curtid >= tid '(4, 0)';
         num = num + 1;

--- a/t/pg-test-files/expected/triggers.sql
+++ b/t/pg-test-files/expected/triggers.sql
@@ -1426,7 +1426,9 @@ BEGIN
         INSERT INTO city_table (city_name, population, country_id)
             VALUES (NEW.city_name, NEW.population, ctry_id)
         RETURNING
-            city_id INTO NEW.city_id;
+            city_id
+        INTO
+            NEW.city_id;
     END IF;
     RETURN NEW;
 END;


### PR DESCRIPTION
Tried to follow the same pattern as used in https://github.com/darold/pgFormatter/commit/3e39cbe76ed003e531f35b3df5a75d862c969d03.

Fixes: https://github.com/darold/pgFormatter/issues/389