### PR TITLE
Add compact-clause-body option to keep the first element of a clause on the keyword line

### DIFF
--- a/lib/pgFormatter/Beautify.pm
+++ b/lib/pgFormatter/Beautify.pm
@@ -164,6 +164,8 @@ Takes options as hash. Following options are recognized:
 
 =item * no_space_function - remove space before function call and open parenthesis
 
+=item * compact_clause_body - keep the first element of a clause on the keyword line
+
 =item * redundant_parenthesis - do not eliminate redundant parenthesis in DML queries
 
 =item * vertical_align - vertically align CREATE TABLE column definitions
@@ -182,7 +184,7 @@ sub new {
 	$self->set_defaults();
 
 	for my $key (
-		qw( query spaces space break wrap keywords functions rules uc_keywords uc_functions uc_types no_comments no_grouping placeholder multiline separator comma comma_break format colorize format_type wrap_limit wrap_after wrap_comment numbering redshift no_extra_line keep_newline no_space_function redundant_parenthesis vertical_align)
+		qw( query spaces space break wrap keywords functions rules uc_keywords uc_functions uc_types no_comments no_grouping placeholder multiline separator comma comma_break format colorize format_type wrap_limit wrap_after wrap_comment numbering redshift no_extra_line keep_newline no_space_function compact_clause_body redundant_parenthesis vertical_align)
 	  )
 	{
 		$self->{$key} = $options{$key} if defined $options{$key};
@@ -3562,7 +3564,9 @@ sub beautify {
 			elsif ($token =~ /^SET$/i
 				&& $self->{'_current_sql_stmt'} eq 'UPDATE' )
 			{
-				$self->_new_line( $token, $last ) if ( !$self->{'wrap_after'} );
+				$self->_new_line( $token, $last )
+				  if ( !$self->{'wrap_after'}
+					and !$self->{'compact_clause_body'} );
 				$self->_over( $token, $last );
 			}
 			elsif (
@@ -3580,7 +3584,8 @@ sub beautify {
 				  )
 				{
 					$self->_new_line( $token, $last )
-					  if ( !$self->{'wrap_after'} );
+					  if ( !$self->{'wrap_after'}
+						and !$self->{'compact_clause_body'} );
 					$self->_over( $token, $last );
 				}
 			}
@@ -3851,7 +3856,9 @@ sub beautify {
 
 		elsif ( $token =~ /^THEN$/i ) {
 			$self->_add_token($token);
-			$self->_new_line( $token, $last );
+			$self->_new_line( $token, $last )
+			  if ( !$self->{'compact_clause_body'}
+				or $#{ $self->{'_is_in_case'} } < 0 );
 			$self->_set_level( $self->{'_level_stack'}[-1], $token, $last )
 			  if (  $self->{'_is_in_if'}
 				and $#{ $self->{'_level_stack'} } >= 0 );
@@ -5567,6 +5574,8 @@ Currently defined defaults:
 
 =item no_space_function => 0
 
+=item compact_clause_body => 0
+
 =item redundant_parenthesis => 0
 
 =item vertical_align => 0
@@ -5612,6 +5621,7 @@ sub set_defaults {
 	$self->{'no_extra_line'}         = 0;
 	$self->{'keep_newline'}          = 0;
 	$self->{'no_space_function'}     = 0;
+	$self->{'compact_clause_body'}   = 0;
 	$self->{'redundant_parenthesis'} = 0;
 	$self->{'vertical_align'}        = 0;
 

--- a/lib/pgFormatter/CLI.pm
+++ b/lib/pgFormatter/CLI.pm
@@ -129,6 +129,7 @@ sub beautify {
 	$args{'extra_function'}        = $self->{'cfg'}->{'extra-function'};
 	$args{'extra_keyword'}         = $self->{'cfg'}->{'extra-keyword'};
 	$args{'no_space_function'}     = $self->{'cfg'}->{'no-space-function'};
+	$args{'compact_clause_body'}   = $self->{'cfg'}->{'compact-clause-body'};
 	$args{'redundant_parenthesis'} = $self->{'cfg'}->{'redundant-parenthesis'};
 	$args{'vertical_align'}        = $self->{'cfg'}->{'vertical-align'};
 
@@ -323,6 +324,9 @@ Options:
 			    keywords defined internaly in pgFormatter.
     --no-space-function : remove space between function call and the open
                             parenthesis.
+    --compact-clause-body : keep the first element of a FROM, WHERE, SET, RETURNING,
+                            HAVING or VALUES clause on the same line as the keyword,
+                            and the body of a CASE ... THEN on the same line as THEN.
     --redundant-parenthesis: do not remove redundant parenthesis in DML.
     --vertical-align      : vertically align CREATE TABLE column definitions and
                             trailing comments.
@@ -393,6 +397,7 @@ sub get_command_line_args {
 		'wrap-limit|w=i',  'wrap-after|W=i',
 		'inplace|i!',      'extra-function=s',
 		'extra-keyword=s', 'no-space-function!',
+		'compact-clause-body!',
 		'redundant-parenthesis!', 'vertical-align!',
 	);
 

--- a/t/02_regress.t
+++ b/t/02_regress.t
@@ -1,4 +1,4 @@
-use Test::Simple tests => 83;
+use Test::Simple tests => 84;
 use File::Temp qw/ tempfile /;
 
 my $pg_format = $ENV{PG_FORMAT} // './pg_format'; # set to the full path to 'pg_format' to test installed binary in /usr/bin
@@ -29,6 +29,7 @@ foreach my $f (@files)
 	$opt = "--no-space-function" if ($f =~ m#/ex70.sql$#);
 	$opt = "--keyword-case 1 --type-case 1" if ($f =~ m#/ex71.sql$#);
 	$opt = "--vertical-align --no-extra-line" if ($f =~ m#/ex81\.sql$#);
+	$opt = "--compact-clause-body" if ($f =~ m#/ex82.sql$#);
 	if ($f =~ m#/ex61.sql$#)
 	{
 		my ($fh, $tmpfile) = tempfile('tmp_pgformatXXXX', SUFFIX => '.lst', TMPDIR => 1, O_TEMPORARY => 1, UNLINK => 1 );

--- a/t/test-files/ex82.sql
+++ b/t/test-files/ex82.sql
@@ -1,0 +1,21 @@
+SELECT
+    plan.id
+    , plan.name
+    , CASE
+        WHEN plan.kind = 'S' THEN 'single'
+        WHEN plan.kind = 'G' THEN 'group'
+        ELSE 'unknown' END AS kind_label
+FROM plan
+    LEFT JOIN agency ON agency.id = plan.agency_id
+WHERE plan.kind IS NOT NULL
+    OR plan.name IS NOT NULL
+    AND (plan.amount > 100
+        OR plan.amount < -100)
+    AND plan.kind IN ('S' , 'G');
+
+UPDATE plan
+SET status = 'done'
+    , updated_at = NOW()
+WHERE id = 42
+RETURNING id
+    , status;

--- a/t/test-files/expected/ex82.sql
+++ b/t/test-files/expected/ex82.sql
@@ -1,0 +1,24 @@
+SELECT
+    plan.id,
+    plan.name,
+    CASE WHEN plan.kind = 'S' THEN 'single'
+    WHEN plan.kind = 'G' THEN 'group'
+    ELSE
+        'unknown'
+    END AS kind_label
+FROM plan
+    LEFT JOIN agency ON agency.id = plan.agency_id
+WHERE plan.kind IS NOT NULL
+    OR plan.name IS NOT NULL
+    AND (plan.amount > 100
+        OR plan.amount < - 100)
+    AND plan.kind IN ('S', 'G');
+
+UPDATE
+    plan
+SET status = 'done',
+    updated_at = NOW()
+WHERE id = 42
+RETURNING id,
+    status;
+


### PR DESCRIPTION
## What

New `--compact-clause-body` option (off by default): the first element of a FROM, WHERE, SET, RETURNING, HAVING or VALUES clause stays on the keyword line, and the body of a CASE ... THEN branch stays on the THEN line.

## Before (default, unchanged)

```sql
SELECT
    plan.id
FROM
    plan
WHERE
    plan.kind IS NOT NULL
    AND plan.kind IN ('S' , 'G');

UPDATE
    plan
SET
    status = 'done'
WHERE id = 42;
```

## After (with --compact-clause-body)

```sql
SELECT
    plan.id
FROM plan
WHERE plan.kind IS NOT NULL
    AND plan.kind IN ('S' , 'G');

UPDATE
    plan
SET status = 'done'
WHERE id = 42;
```

Further elements still break on their separator, so a FROM followed by joins keeps them one per line.

## Motivation

Keeping the clause body attached to the keyword reads better for short clauses and produces smaller diffs when a clause gains or loses its first element. Because it is a new option, existing users are not affected unless they opt in.

## Tests

- t/test-files/ex82.sql + t/test-files/expected/ex82.sql cover SELECT/FROM/WHERE, UPDATE/SET/WHERE/RETURNING and CASE/THEN.
- Full suite: prove -lv t/ passes (90 tests).
- Output is idempotent (formatting the formatted output is a no-op).
