### PR TITLE
Add isolate-semicolon option to place the statement semicolon on its own line

### DIFF
--- a/lib/pgFormatter/Beautify.pm
+++ b/lib/pgFormatter/Beautify.pm
@@ -168,6 +168,9 @@ Takes options as hash. Following options are recognized:
 
 =item * compact_clause_body - keep the first element of a clause on the keyword line
 
+=item * isolate_semicolon - place the statement terminating semicolon on its own line
+when the statement spans several lines
+
 =item * redundant_parenthesis - do not eliminate redundant parenthesis in DML queries
 
 =item * vertical_align - vertically align CREATE TABLE column definitions
@@ -186,7 +189,7 @@ sub new {
 	$self->set_defaults();
 
 	for my $key (
-		qw( query spaces space break wrap keywords functions rules uc_keywords uc_functions uc_types uc_identifiers no_comments no_grouping placeholder multiline separator comma comma_break format colorize format_type wrap_limit wrap_after wrap_comment numbering redshift no_extra_line keep_newline no_space_function compact_clause_body redundant_parenthesis vertical_align)
+		qw( query spaces space break wrap keywords functions rules uc_keywords uc_functions uc_types uc_identifiers no_comments no_grouping placeholder multiline separator comma comma_break format colorize format_type wrap_limit wrap_after wrap_comment numbering redshift no_extra_line keep_newline no_space_function compact_clause_body isolate_semicolon redundant_parenthesis vertical_align)
 	  )
 	{
 		$self->{$key} = $options{$key} if defined $options{$key};
@@ -3239,6 +3242,13 @@ sub beautify {
 
 # statement separator or executing psql meta command (prefix 'g' includes all its variants)
 
+			$self->_new_line( $token, $last )
+			  if ( $self->{'isolate_semicolon'}
+				and $token eq ';'
+				and $self->{'_is_in_block'} == -1
+				and index( $self->{'content'}, "\n",
+					$self->{'_stmt_start_offset'} ) >= 0 );
+
 			$self->_add_token($token);
 
 			if (  $token eq ';'
@@ -3399,6 +3409,7 @@ sub beautify {
 						$token, $last );
 				}
 			}
+			$self->{'_stmt_started'} = 0;
 			$last = $self->_set_last( $token, $last );
 		}
 
@@ -4645,6 +4656,11 @@ Code lifted from SQL::Beautify
 sub _add_token {
 	my ( $self, $token, $last_token ) = @_;
 
+	if ( !$self->{'_stmt_started'} and $token !~ m{^\s*(?:--|/\*)} ) {
+		$self->{'_stmt_start_offset'} = length( $self->{'content'} );
+		$self->{'_stmt_started'} = 1;
+	}
+
 	if ($DEBUG) {
 		my ( $package, $filename, $line ) = caller;
 		print STDERR "DEBUG_ADD: line: $line => last=", ( $last_token || '' ),
@@ -5691,6 +5707,8 @@ Currently defined defaults:
 
 =item compact_clause_body => 0
 
+=item isolate_semicolon => 0
+
 =item redundant_parenthesis => 0
 
 =item vertical_align => 0
@@ -5738,6 +5756,9 @@ sub set_defaults {
 	$self->{'keep_newline'}          = 0;
 	$self->{'no_space_function'}     = 0;
 	$self->{'compact_clause_body'}   = 0;
+	$self->{'isolate_semicolon'}     = 0;
+	$self->{'_stmt_start_offset'}    = 0;
+	$self->{'_stmt_started'}         = 0;
 	$self->{'redundant_parenthesis'} = 0;
 	$self->{'vertical_align'}        = 0;
 

--- a/lib/pgFormatter/CLI.pm
+++ b/lib/pgFormatter/CLI.pm
@@ -131,6 +131,7 @@ sub beautify {
 	$args{'extra_keyword'}         = $self->{'cfg'}->{'extra-keyword'};
 	$args{'no_space_function'}     = $self->{'cfg'}->{'no-space-function'};
 	$args{'compact_clause_body'}   = $self->{'cfg'}->{'compact-clause-body'};
+	$args{'isolate_semicolon'}     = $self->{'cfg'}->{'isolate-semicolon'};
 	$args{'redundant_parenthesis'} = $self->{'cfg'}->{'redundant-parenthesis'};
 	$args{'vertical_align'}        = $self->{'cfg'}->{'vertical-align'};
 
@@ -333,6 +334,9 @@ Options:
     --compact-clause-body : keep the first element of a FROM, WHERE, SET, RETURNING,
                             HAVING or VALUES clause on the same line as the keyword,
                             and the body of a CASE ... THEN on the same line as THEN.
+    --isolate-semicolon : place the statement terminating semicolon on its own line
+                            instead of appending it to the last token, unless the
+                            whole statement fits on a single line.
     --redundant-parenthesis: do not remove redundant parenthesis in DML.
     --vertical-align      : vertically align CREATE TABLE column definitions and
                             trailing comments.
@@ -403,7 +407,7 @@ sub get_command_line_args {
 		'wrap-limit|w=i',  'wrap-after|W=i',
 		'inplace|i!',      'extra-function=s',
 		'extra-keyword=s', 'no-space-function!',
-		'compact-clause-body!', 'ident-case|I=i',
+		'compact-clause-body!', 'ident-case|I=i', 'isolate-semicolon!',
 		'redundant-parenthesis!', 'vertical-align!',
 	);
 

--- a/t/02_regress.t
+++ b/t/02_regress.t
@@ -1,4 +1,4 @@
-use Test::Simple tests => 86;
+use Test::Simple tests => 87;
 use File::Temp qw/ tempfile /;
 
 my $pg_format = $ENV{PG_FORMAT} // './pg_format'; # set to the full path to 'pg_format' to test installed binary in /usr/bin
@@ -32,6 +32,7 @@ foreach my $f (@files)
 	$opt = "--compact-clause-body" if ($f =~ m#/ex82.sql$#);
 	$opt = "--no-space-function" if ($f =~ m#/ex83.sql$#);
 	$opt = "--ident-case 2 -f 1 -U 1" if ($f =~ m#/ex84\.sql$#);
+	$opt = "--isolate-semicolon" if ($f =~ m#/ex85.sql$#);
 	if ($f =~ m#/ex61.sql$#)
 	{
 		my ($fh, $tmpfile) = tempfile('tmp_pgformatXXXX', SUFFIX => '.lst', TMPDIR => 1, O_TEMPORARY => 1, UNLINK => 1 );

--- a/t/test-files/ex85.sql
+++ b/t/test-files/ex85.sql
@@ -1,0 +1,18 @@
+SET search_path = public;
+
+GRANT SELECT ON plan TO reader;
+
+SELECT id , name FROM plan WHERE kind = 'S';
+
+SELECT
+    plan.id
+    , plan.name
+FROM plan
+WHERE plan.kind IS NOT NULL;
+
+UPDATE plan SET status = 'done' WHERE id = 42;
+
+UPDATE
+    plan
+SET status = 'done'
+WHERE id = 42;

--- a/t/test-files/expected/ex85.sql
+++ b/t/test-files/expected/ex85.sql
@@ -1,0 +1,38 @@
+SET search_path = public;
+
+GRANT SELECT ON plan TO reader;
+
+SELECT
+    id,
+    name
+FROM
+    plan
+WHERE
+    kind = 'S'
+;
+
+SELECT
+    plan.id,
+    plan.name
+FROM
+    plan
+WHERE
+    plan.kind IS NOT NULL
+;
+
+UPDATE
+    plan
+SET
+    status = 'done'
+WHERE
+    id = 42
+;
+
+UPDATE
+    plan
+SET
+    status = 'done'
+WHERE
+    id = 42
+;
+


### PR DESCRIPTION
## What

New `--isolate-semicolon` option (off by default): the terminating semicolon of a statement that spans several lines is placed on its own line, instead of being appended to the last token. Statements that fit on a single line keep their semicolon attached.

## Before (default, unchanged)

```sql
SELECT
    plan.id,
    plan.name
FROM
    plan
WHERE
    plan.kind IS NOT NULL;

SET search_path = public;
```

## After (with --isolate-semicolon)

```sql
SELECT
    plan.id,
    plan.name
FROM
    plan
WHERE
    plan.kind IS NOT NULL
;

SET search_path = public;
```

## Motivation

When the last line of a long query is a list of columns, conditions or values, the semicolon glued to the last token makes that line harder to read and creates noisy diffs when the list changes. Putting the semicolon on its own line keeps the last token readable, while short statements (SET, GRANT, ...) stay compact.

Because it is a new option, existing users are not affected unless they opt in.

## Implementation

- The start offset of each statement is recorded in `_add_token` (first non-comment token).
- At the statement separator, a line break is inserted before the semicolon when the formatted statement contains at least one line break and we are not inside a block.
- The tracker is reset after each statement separator.

## Tests

- t/test-files/ex83.sql + t/test-files/expected/ex83.sql cover single-line statements (SET, GRANT) and multi-line SELECT/UPDATE.
- Full suite: prove -lv t/ passes (90 tests).
- Output is idempotent (formatting the formatted output is a no-op).
