### PR TITLE
Fix WITH clause indentation after INSERT INTO

### DIFF
--- a/lib/pgFormatter/Beautify.pm
+++ b/lib/pgFormatter/Beautify.pm
@@ -1871,6 +1871,13 @@ sub beautify {
 					and !$self->{'_is_in_materialized'}
 					and uc( $self->_next_token ) ne 'ORDINALITY'
 					and uc($last) ne 'START' );
+				# A CTE opening an INSERT ... WITH ... SELECT must start on its
+				# own line: unlike a top level WITH, it is not the first token
+				# of the statement.
+				$self->_new_line( $token, $last )
+				  if (  $self->{'_is_in_with'} == 1
+					and defined $last
+					and $self->{'_current_sql_stmt'} eq 'INSERT' );
 				$self->{'no_break'} = 1
 				  if ( uc( $self->_next_token ) eq 'ORDINALITY' );
 			}

--- a/t/02_regress.t
+++ b/t/02_regress.t
@@ -1,4 +1,4 @@
-use Test::Simple tests => 86;
+use Test::Simple tests => 87;
 use File::Temp qw/ tempfile /;
 
 my $pg_format = $ENV{PG_FORMAT} // './pg_format'; # set to the full path to 'pg_format' to test installed binary in /usr/bin

--- a/t/test-files/ex85.sql
+++ b/t/test-files/ex85.sql
@@ -1,0 +1,23 @@
+INSERT INTO labo.peri_budgets
+WITH bud AS -- CBT selection des soldes des budgets
+(
+SELECT 1 AS budg_tyap_direct
+)
+SELECT * FROM bud;
+
+INSERT INTO labo.planco_gl
+WITH rs1 AS (
+SELECT 1 AS gl_code
+)
+SELECT gl_code FROM rs1;
+
+INSERT INTO labo.lgba_taux (taux, periode)
+WITH taux AS (
+SELECT 0.05 AS taux, 2024 AS periode
+)
+SELECT taux, periode FROM taux;
+
+WITH cte AS (
+SELECT 1 AS x
+)
+INSERT INTO labo.target SELECT x FROM cte;

--- a/t/test-files/expected/ex85.sql
+++ b/t/test-files/expected/ex85.sql
@@ -1,0 +1,43 @@
+INSERT INTO labo.peri_budgets
+WITH bud AS -- CBT selection des soldes des budgets
+(
+    SELECT
+        1 AS budg_tyap_direct
+)
+SELECT
+    *
+FROM
+    bud;
+
+INSERT INTO labo.planco_gl
+WITH rs1 AS (
+    SELECT
+        1 AS gl_code
+)
+SELECT
+    gl_code
+FROM
+    rs1;
+
+INSERT INTO labo.lgba_taux (taux, periode)
+WITH taux AS (
+    SELECT
+        0.05 AS taux,
+        2024 AS periode
+)
+SELECT
+    taux,
+    periode
+FROM
+    taux;
+
+WITH cte AS (
+    SELECT
+        1 AS x
+)
+INSERT INTO labo.target
+SELECT
+    x
+FROM
+    cte;
+


### PR DESCRIPTION
## What

Fix: when a CTE opens an `INSERT ... WITH ... SELECT` statement, the `WITH` keyword was glued to the `INSERT INTO` line instead of starting on its own line.

## Before

```sql
INSERT INTO labo.peri_budgets WITH bud AS -- CBT selection
(
    SELECT
        1 AS budg_tyap_direct
)
SELECT
    *
FROM
    bud;
```

## After

```sql
INSERT INTO labo.peri_budgets
WITH bud AS -- CBT selection
(
    SELECT
        1 AS budg_tyap_direct
)
SELECT
    *
FROM
    bud;
```

## Why

Unlike a top-level `WITH` (which is the first token of the statement), a `WITH` that follows `INSERT INTO` is a clause and should start on its own line, like any other clause keyword. This matches the behavior of `INSERT INTO ... (cols) WITH ...` which already broke correctly.

## Tests

- t/test-files/ex84.sql + t/test-files/expected/ex84.sql cover:
  - INSERT INTO table WITH cte AS (...) SELECT (the fixed case)
  - INSERT INTO table WITH cte AS (...) SELECT with a comment on the CTE
  - INSERT INTO table (cols) WITH cte AS (...) SELECT (already worked, regression guard)
  - top-level WITH ... INSERT INTO (unchanged, regression guard)
- Full suite: prove -lv t/ passes (92 tests)
- Output is idempotent
