### PR TITLE
Add --join-subquery-level option to fix first-join indentation in subqueries

### DIFF
--- a/lib/pgFormatter/Beautify.pm
+++ b/lib/pgFormatter/Beautify.pm
@@ -168,6 +168,8 @@ Takes options as hash. Following options are recognized:
 
 =item * compact_clause_body - keep the first element of a clause on the keyword line
 
+=item * join_subquery_level - compensate the indentation step-back of the first join of a subquery whatever the nesting level, so the subquery does not lose one level
+
 =item * redundant_parenthesis - do not eliminate redundant parenthesis in DML queries
 
 =item * vertical_align - vertically align CREATE TABLE column definitions
@@ -186,7 +188,7 @@ sub new {
 	$self->set_defaults();
 
 	for my $key (
-		qw( query spaces space break wrap keywords functions rules uc_keywords uc_functions uc_types uc_identifiers no_comments no_grouping placeholder multiline separator comma comma_break format colorize format_type wrap_limit wrap_after wrap_comment numbering redshift no_extra_line keep_newline no_space_function compact_clause_body redundant_parenthesis vertical_align)
+		qw( query spaces space break wrap keywords functions rules uc_keywords uc_functions uc_types uc_identifiers no_comments no_grouping placeholder multiline separator comma comma_break format colorize format_type wrap_limit wrap_after wrap_comment numbering redshift no_extra_line keep_newline no_space_function compact_clause_body join_subquery_level redundant_parenthesis vertical_align)
 	  )
 	{
 		$self->{$key} = $options{$key} if defined $options{$key};
@@ -4085,11 +4087,20 @@ sub beautify {
 
 			if ( $token =~ /(?:LEFT|RIGHT|FULL|CROSS|NATURAL)$/i ) {
 				$self->_new_line( $token, $last );
-				$self->_over( $token, $last )
-				  if (
-					$self->{'_level'} == 0
-					|| ( $self->{'_is_in_with'} > 1 and $self->{'_level'} == 1 )
-				  );
+				# When join_subquery_level is enabled, mirror the INNER/OUTER branch
+				# below: stepping back is compensated whatever the nesting level, so
+				# the first join of a subquery no longer loses one level for the
+				# whole subquery.
+				if ( $self->{'join_subquery_level'} ) {
+					$self->_over( $token, $last ) if ( !$self->{'_is_in_join'} );
+				}
+				else {
+					$self->_over( $token, $last )
+					  if (
+						$self->{'_level'} == 0
+						|| ( $self->{'_is_in_with'} > 1 and $self->{'_level'} == 1 )
+					  );
+				}
 			}
 			if (   ( $token =~ /(?:INNER|OUTER)$/i )
 				&& ( $last !~ /(?:LEFT|RIGHT|CROSS|NATURAL|FULL)$/i ) )
@@ -5691,6 +5702,8 @@ Currently defined defaults:
 
 =item compact_clause_body => 0
 
+=item join_subquery_level => 0
+
 =item redundant_parenthesis => 0
 
 =item vertical_align => 0
@@ -5738,6 +5751,7 @@ sub set_defaults {
 	$self->{'keep_newline'}          = 0;
 	$self->{'no_space_function'}     = 0;
 	$self->{'compact_clause_body'}   = 0;
+	$self->{'join_subquery_level'} = 0;
 	$self->{'redundant_parenthesis'} = 0;
 	$self->{'vertical_align'}        = 0;
 

--- a/lib/pgFormatter/CLI.pm
+++ b/lib/pgFormatter/CLI.pm
@@ -131,6 +131,7 @@ sub beautify {
 	$args{'extra_keyword'}         = $self->{'cfg'}->{'extra-keyword'};
 	$args{'no_space_function'}     = $self->{'cfg'}->{'no-space-function'};
 	$args{'compact_clause_body'}   = $self->{'cfg'}->{'compact-clause-body'};
+	$args{'join_subquery_level'} = $self->{'cfg'}->{'join-subquery-level'};
 	$args{'redundant_parenthesis'} = $self->{'cfg'}->{'redundant-parenthesis'};
 	$args{'vertical_align'}        = $self->{'cfg'}->{'vertical-align'};
 
@@ -333,6 +334,9 @@ Options:
     --compact-clause-body : keep the first element of a FROM, WHERE, SET, RETURNING,
                             HAVING or VALUES clause on the same line as the keyword,
                             and the body of a CASE ... THEN on the same line as THEN.
+    --join-subquery-level : compensate the indentation step-back of the first join
+                            of a subquery whatever the nesting level, so the subquery
+                            does not lose one level.
     --redundant-parenthesis: do not remove redundant parenthesis in DML.
     --vertical-align      : vertically align CREATE TABLE column definitions and
                             trailing comments.
@@ -403,7 +407,7 @@ sub get_command_line_args {
 		'wrap-limit|w=i',  'wrap-after|W=i',
 		'inplace|i!',      'extra-function=s',
 		'extra-keyword=s', 'no-space-function!',
-		'compact-clause-body!', 'ident-case|I=i',
+		'compact-clause-body!', 'join-subquery-level!', 'ident-case|I=i',
 		'redundant-parenthesis!', 'vertical-align!',
 	);
 

--- a/t/02_regress.t
+++ b/t/02_regress.t
@@ -1,4 +1,4 @@
-use Test::Simple tests => 86;
+use Test::Simple tests => 87;
 use File::Temp qw/ tempfile /;
 
 my $pg_format = $ENV{PG_FORMAT} // './pg_format'; # set to the full path to 'pg_format' to test installed binary in /usr/bin
@@ -32,6 +32,7 @@ foreach my $f (@files)
 	$opt = "--compact-clause-body" if ($f =~ m#/ex82.sql$#);
 	$opt = "--no-space-function" if ($f =~ m#/ex83.sql$#);
 	$opt = "--ident-case 2 -f 1 -U 1" if ($f =~ m#/ex84\.sql$#);
+	$opt = "--join-subquery-level" if ($f =~ m#/ex85.sql$#);
 	if ($f =~ m#/ex61.sql$#)
 	{
 		my ($fh, $tmpfile) = tempfile('tmp_pgformatXXXX', SUFFIX => '.lst', TMPDIR => 1, O_TEMPORARY => 1, UNLINK => 1 );

--- a/t/test-files/ex85.sql
+++ b/t/test-files/ex85.sql
@@ -1,0 +1,25 @@
+SELECT
+    price.column1
+FROM
+    (SELECT
+        library.column1
+        , librarystat.column2
+    FROM
+        library
+        LEFT OUTER JOIN db1.v_table3 librarystat ON librarystat.column1 = library.column1
+            AND librarystat.column2 = library.column2
+    ) AS price
+WHERE
+    price.column1 < 'R45';
+
+SELECT
+    test_c.column1
+FROM
+    (SELECT
+        test_1a.column1
+    FROM
+        dual
+        CROSS JOIN (
+            SELECT
+                max(2) AS test_b
+            FROM dual) test_1b) test_c;

--- a/t/test-files/expected/ex85.sql
+++ b/t/test-files/expected/ex85.sql
@@ -1,0 +1,26 @@
+SELECT
+    price.column1
+FROM (
+    SELECT
+        library.column1,
+        librarystat.column2
+    FROM
+        library
+        LEFT OUTER JOIN db1.v_table3 librarystat ON librarystat.column1 = library.column1
+        AND librarystat.column2 = library.column2) AS price
+WHERE
+    price.column1 < 'R45';
+
+SELECT
+    test_c.column1
+FROM (
+    SELECT
+        test_1a.column1
+    FROM
+        dual
+        CROSS JOIN (
+            SELECT
+                max(2) AS test_b
+            FROM
+                dual) test_1b) test_c;
+


### PR DESCRIPTION
## What

Add a new option `--join-subquery-level` that compensates the indentation step-back of the first join of a subquery whatever the nesting level, so the subquery does not lose one level.

The option is **off by default** — the existing behavior is fully preserved.

## Behavior

Consider a join that is the first join of a subquery:

```sql
SELECT price.column1
FROM (
    SELECT library.column1, librarystat.column2
    FROM library
    LEFT OUTER JOIN db1.v_table3 librarystat
        ON librarystat.column1 = library.column1
) AS price;
```

**Without the option (default, unchanged)** — the first join of the subquery loses one level and ends up aligned with `FROM`:

```sql
FROM (
    SELECT
        library.column1,
        librarystat.column2
    FROM
        library
    LEFT OUTER JOIN db1.v_table3 librarystat ON librarystat.column1 = library.column1
    AND librarystat.column2 = library.column2) AS price
```

**With `--join-subquery-level`** — the join stays at the same level as the other `FROM` items:

```sql
FROM (
    SELECT
        library.column1,
        librarystat.column2
    FROM
        library
        LEFT OUTER JOIN db1.v_table3 librarystat ON librarystat.column1 = library.column1
        AND librarystat.column2 = library.column2) AS price
```

## Why

This was initially intended as a **bug fix**: the first join of a subquery loses one indentation level for the whole subquery, which is inconsistent with the other `FROM` items. However, changing the default output would alter the formatting of existing users (it changes the expected output of the regression tests `ex1.sql` and `ex58.sql`). To avoid breaking the existing behavior, it was deliberately shipped as an **opt-in option** instead of a behavior change.

## Implementation

- `lib/pgFormatter/Beautify.pm`: new `join_subquery_level` option (POD, `qw()` list, `set_defaults`). The `LEFT|RIGHT|FULL|CROSS|NATURAL` join branch now mirrors the `INNER|OUTER` branch (step-back compensated via `!_is_in_join`) when the option is on, and keeps the previous level-based condition when it is off.
- `lib/pgFormatter/CLI.pm`: `--join-subquery-level` CLI flag, config mapping, and help text.
- `t/test-files/ex85.sql` + `t/test-files/expected/ex85.sql`: regression test covering a `LEFT OUTER JOIN` and a `CROSS JOIN` as the first join of a subquery, run with `--join-subquery-level`.

## Tests

- `prove -lv t/` passes (93 tests). `ex1.sql` and `ex58.sql` still pass because the default behavior is unchanged.
- Output is idempotent with the option enabled.
