### PR TITLE
Add --break-insert-columns option to break before INSERT column list closing paren

### DIFF
--- a/lib/pgFormatter/Beautify.pm
+++ b/lib/pgFormatter/Beautify.pm
@@ -168,6 +168,9 @@ Takes options as hash. Following options are recognized:
 
 =item * compact_clause_body - keep the first element of a clause on the keyword line
 
+=item * break_insert_columns - break the line before the parenthesis closing the
+column list of an INSERT
+
 =item * redundant_parenthesis - do not eliminate redundant parenthesis in DML queries
 
 =item * vertical_align - vertically align CREATE TABLE column definitions
@@ -186,7 +189,7 @@ sub new {
 	$self->set_defaults();
 
 	for my $key (
-		qw( query spaces space break wrap keywords functions rules uc_keywords uc_functions uc_types uc_identifiers no_comments no_grouping placeholder multiline separator comma comma_break format colorize format_type wrap_limit wrap_after wrap_comment numbering redshift no_extra_line keep_newline no_space_function compact_clause_body redundant_parenthesis vertical_align)
+		qw( query spaces space break wrap keywords functions rules uc_keywords uc_functions uc_types uc_identifiers no_comments no_grouping placeholder multiline separator comma comma_break format colorize format_type wrap_limit wrap_after wrap_comment numbering redshift no_extra_line keep_newline no_space_function compact_clause_body break_insert_columns redundant_parenthesis vertical_align)
 	  )
 	{
 		$self->{$key} = $options{$key} if defined $options{$key};
@@ -3018,10 +3021,19 @@ sub beautify {
 						or $self->_next_token eq ';' )
 				  );
 				$add_nl = 1
-				  if ( $self->{'_current_sql_stmt'} ne 'INSERT'
+				  if ( ( $self->{'_current_sql_stmt'} ne 'INSERT'
+						or $self->{'break_insert_columns'} )
 					and !$self->{'_is_in_function'}
-					and ( defined $self->_next_token
-						and $self->_next_token =~ /^(SELECT|WITH)$/i )
+					and defined $self->_next_token
+					and (
+						# Default: break before SELECT/WITH for non-INSERT statements.
+						( $self->{'_current_sql_stmt'} ne 'INSERT'
+							and $self->_next_token =~ /^(SELECT|WITH)$/i )
+						# Option: also break before VALUES for INSERT statements.
+						or ( $self->{'_current_sql_stmt'} eq 'INSERT'
+							and $self->{'break_insert_columns'}
+							and $self->_next_token =~ /^(SELECT|WITH|VALUES)$/i )
+					)
 					and $self->{'_tokens'}[1] !~ /^(ORDINALITY|FUNCTION)$/i
 					and (  $self->{'_is_in_create'}
 						or $last ne ')' and $last ne ']' )
@@ -5691,6 +5703,8 @@ Currently defined defaults:
 
 =item compact_clause_body => 0
 
+=item break_insert_columns => 0
+
 =item redundant_parenthesis => 0
 
 =item vertical_align => 0
@@ -5738,6 +5752,7 @@ sub set_defaults {
 	$self->{'keep_newline'}          = 0;
 	$self->{'no_space_function'}     = 0;
 	$self->{'compact_clause_body'}   = 0;
+	$self->{'break_insert_columns'}  = 0;
 	$self->{'redundant_parenthesis'} = 0;
 	$self->{'vertical_align'}        = 0;
 

--- a/lib/pgFormatter/CLI.pm
+++ b/lib/pgFormatter/CLI.pm
@@ -131,6 +131,7 @@ sub beautify {
 	$args{'extra_keyword'}         = $self->{'cfg'}->{'extra-keyword'};
 	$args{'no_space_function'}     = $self->{'cfg'}->{'no-space-function'};
 	$args{'compact_clause_body'}   = $self->{'cfg'}->{'compact-clause-body'};
+	$args{'break_insert_columns'}  = $self->{'cfg'}->{'break-insert-columns'};
 	$args{'redundant_parenthesis'} = $self->{'cfg'}->{'redundant-parenthesis'};
 	$args{'vertical_align'}        = $self->{'cfg'}->{'vertical-align'};
 
@@ -333,6 +334,9 @@ Options:
     --compact-clause-body : keep the first element of a FROM, WHERE, SET, RETURNING,
                             HAVING or VALUES clause on the same line as the keyword,
                             and the body of a CASE ... THEN on the same line as THEN.
+    --break-insert-columns : break the line before the parenthesis closing the
+                            column list of an INSERT, like every other
+                            parenthesized list.
     --redundant-parenthesis: do not remove redundant parenthesis in DML.
     --vertical-align      : vertically align CREATE TABLE column definitions and
                             trailing comments.
@@ -403,7 +407,7 @@ sub get_command_line_args {
 		'wrap-limit|w=i',  'wrap-after|W=i',
 		'inplace|i!',      'extra-function=s',
 		'extra-keyword=s', 'no-space-function!',
-		'compact-clause-body!', 'ident-case|I=i',
+		'compact-clause-body!', 'break-insert-columns!', 'ident-case|I=i',
 		'redundant-parenthesis!', 'vertical-align!',
 	);
 

--- a/t/02_regress.t
+++ b/t/02_regress.t
@@ -1,4 +1,4 @@
-use Test::Simple tests => 86;
+use Test::Simple tests => 87;
 use File::Temp qw/ tempfile /;
 
 my $pg_format = $ENV{PG_FORMAT} // './pg_format'; # set to the full path to 'pg_format' to test installed binary in /usr/bin
@@ -32,6 +32,7 @@ foreach my $f (@files)
 	$opt = "--compact-clause-body" if ($f =~ m#/ex82.sql$#);
 	$opt = "--no-space-function" if ($f =~ m#/ex83.sql$#);
 	$opt = "--ident-case 2 -f 1 -U 1" if ($f =~ m#/ex84\.sql$#);
+	$opt = "--break-insert-columns" if ($f =~ m#/ex85.sql$#);
 	if ($f =~ m#/ex61.sql$#)
 	{
 		my ($fh, $tmpfile) = tempfile('tmp_pgformatXXXX', SUFFIX => '.lst', TMPDIR => 1, O_TEMPORARY => 1, UNLINK => 1 );

--- a/t/test-files/ex85.sql
+++ b/t/test-files/ex85.sql
@@ -1,0 +1,10 @@
+INSERT INTO mytable (col1, col2, col3)
+VALUES (1, 2, 3);
+
+INSERT INTO mytable (col1, col2, col3)
+SELECT
+    a,
+    b,
+    c
+FROM
+    other;

--- a/t/test-files/expected/ex85.sql
+++ b/t/test-files/expected/ex85.sql
@@ -1,0 +1,13 @@
+INSERT INTO mytable (col1, col2, col3
+)
+    VALUES (1, 2, 3);
+
+INSERT INTO mytable (col1, col2, col3
+)
+SELECT
+    a,
+    b,
+    c
+FROM
+    other;
+


### PR DESCRIPTION
## What

Add a new option `--break-insert-columns` that breaks the line before the parenthesis closing the column list of an `INSERT`, like every other parenthesized list.

The option is **off by default** — the existing behavior is fully preserved.

## Behavior

**Without the option (default, unchanged):**

```sql
INSERT INTO mytable (col1, col2, col3)
    VALUES (1, 2, 3);
```

**With `--break-insert-columns`:**

```sql
INSERT INTO mytable (col1, col2, col3
)
    VALUES (1, 2, 3);
```

## Why

By default pgFormatter keeps the closing parenthesis of an `INSERT` column list on the same line, which is inconsistent with the way every other parenthesized list (subqueries, function calls, …) is broken. This option provides the consistent style without changing the default output.

## Implementation

- `lib/pgFormatter/Beautify.pm`: new `break_insert_columns` option (POD, `qw()` list, `set_defaults`). The `$add_nl` condition that breaks before a `)` followed by `SELECT`/`WITH` is extended so that, **only for `INSERT` statements and only when the option is on**, it also breaks before `VALUES`.
- `lib/pgFormatter/CLI.pm`: `--break-insert-columns` CLI flag, config mapping, and help text.
- `t/test-files/ex85.sql` + `t/test-files/expected/ex85.sql`: regression test covering `INSERT … (cols) VALUES` and `INSERT … (cols) SELECT`, run with `--break-insert-columns`.

### Note on the `VALUES` extension

The original upstream condition only breaks before `)` when the next token is `SELECT` or `WITH`. To also break before `VALUES` (the common `INSERT … (cols) VALUES` case), `VALUES` had to be added to the matched tokens. This was done **gated on the statement being an `INSERT` and the option being on**, so it does not alter the default behavior of other statements (e.g. a `MERGE … INSERT (a, b) VALUES` clause, covered by the existing `ex79.sql` test, is left unchanged).

## Tests

- `prove -lv t/` passes (93 tests), including the existing `ex79.sql` (MERGE with an `INSERT … VALUES` clause) which still passes because the default behavior is unchanged.
- Output is idempotent with the option enabled.
