### PR TITLE
Fix non-converging indentation of adjacent string constants

### DIFF
--- a/lib/pgFormatter/Beautify.pm
+++ b/lib/pgFormatter/Beautify.pm
@@ -4705,7 +4705,12 @@ sub _add_token {
 				{
 					if ( $token !~ /^['"].*['"]$/ or $last_token ne ':' ) {
 						if ( $token =~ /AAKEYWCONST\d+AA\s+AAKEYWCONST\d+AA/ ) {
-							$token =~ s/(AAKEYWCONST\d+AA)/$sp$1/gs;
+							# Rebuild the separators, the tokenizer kept them verbatim
+							my $nl_sp = $self->{'space'} x
+							  ( $self->{'spaces'} * ( $self->{'_level'} // 0 ) );
+							$token =~ s/[ \t]+(AAKEYWCONST\d+AA)/ $1/gs;
+							$token =~ s/ ?\n ?(AAKEYWCONST\d+AA)/\n$nl_sp$1/gs;
+							$token =~ s/^(AAKEYWCONST\d+AA)/$sp$1/s;
 						}
 						else {
 							$self->{'content'} .= $sp

--- a/t/02_regress.t
+++ b/t/02_regress.t
@@ -1,4 +1,4 @@
-use Test::Simple tests => 86;
+use Test::Simple tests => 87;
 use File::Temp qw/ tempfile /;
 
 my $pg_format = $ENV{PG_FORMAT} // './pg_format'; # set to the full path to 'pg_format' to test installed binary in /usr/bin

--- a/t/test-files/ex85.sql
+++ b/t/test-files/ex85.sql
@@ -1,0 +1,17 @@
+SELECT 'a'
+'b' AS lit
+FROM t;
+
+SELECT concat('CLOTURE AVGLI PROP LOCATAIRE ' , l.imme_no , ' AU '
+'2024-12-31') AS libelle
+FROM locataires l;
+
+SELECT 'one'
+'two'
+'three' AS parts
+FROM t;
+
+SELECT *
+FROM t
+WHERE t.code = 'pre'
+'fix';

--- a/t/test-files/expected/ex85.sql
+++ b/t/test-files/expected/ex85.sql
@@ -1,0 +1,27 @@
+SELECT
+    'a'
+    'b' AS lit
+FROM
+    t;
+
+SELECT
+    concat('CLOTURE AVGLI PROP LOCATAIRE ', l.imme_no, ' AU '
+        '2024-12-31') AS libelle
+FROM
+    locataires l;
+
+SELECT
+    'one'
+    'two'
+    'three' AS parts
+FROM
+    t;
+
+SELECT
+    *
+FROM
+    t
+WHERE
+    t.code = 'pre'
+    'fix';
+


### PR DESCRIPTION
## What

Fix: adjacent string constants separated by a newline (implicit concatenation) gained one space of indentation on every run, so the output never converged.

Fixes #410.

## Before

Formatting the same input three times in a row:

```sql
SELECT
    concat('a', x, ' AU '
 'b') AS lib
FROM
    t;
```

```sql
SELECT
    concat('a', x, ' AU '
  'b') AS lib
FROM
    t;
```

```sql
SELECT
    concat('a', x, ' AU '
   'b') AS lib
FROM
    t;
```

## After

```sql
SELECT
    concat('a', x, ' AU '
        'b') AS lib
FROM
    t;
```

Stable from the first run, and the continuation line now follows the current indentation instead of staying at column 1.

## Why

`tokenize_sql` keeps consecutive constants in a single token and preserves the whitespace between them verbatim (the rule commented `preserved multiple constants with newline`). `_add_token` then prefixed `$sp` to every constant of that token without normalizing the whitespace already present. `$sp` is a single space when the token is not at the start of a line, so each run appended one more space to what the previous run had produced.

The fix rebuilds the separators rather than prefixing them: a single space when the constants are on the same line, the current indentation after a newline. That makes the result independent of the input spacing, which is what idempotency requires.

## Tests

- t/test-files/ex85.sql + t/test-files/expected/ex85.sql cover:
  - two constants on consecutive lines in a select list
  - two constants as the last argument of a function call (the nesting case)
  - three constants chained over three lines
  - two constants in a WHERE comparison
- Full suite: prove -l t/ passes (93 tests)
- Output is idempotent, verified over three further runs on the expected file